### PR TITLE
Changed exception to runtime_error base class for exception handling

### DIFF
--- a/src/baseexc.hpp
+++ b/src/baseexc.hpp
@@ -14,50 +14,47 @@
 #ifndef __BASEEXC_HPP__
 #define __BASEEXC_HPP__
 
-#include <exception>
+#include <stdexcept>
 #include <string>
+#include <sstream>
 
 namespace MetaSim {
 
-    /** 
+    /**
         \ingroup metasim_exc
-      
+
         Basic exception class.
-      
+
         This class is the base used for handling exceptions. Any
-        exception of the simulator has to be derived from this class .
-      
-        @version 1.1 
-        @author Antonino Casile, Luigi Palopoli
+        exception of the simulator has to be derived from this class.
+
+        @version 1.2
+        @author Antonino Casile, Luigi Palopoli, Alessio Balsini
     */
-    class BaseExc : public std::exception {
+    class BaseExc : public std::runtime_error {
     protected:
         /// Contains a brief description of the exception.
         std::string _what;
 
     public:
-        /** Constructor. 
+        /** Constructor.
          *  @param message contains the error message.
-         *  @param cl contains the name of the class where the exception has been 
+         *  @param cl contains the name of the class where the exception has been
          *  raised.
-         *  @param md contains the name of the module where the exception 
-         *  has been raised. 
+         *  @param md contains the name of the module where the exception
+         *  has been raised.
          */
         BaseExc(const std::string &message,
                 const std::string &cl="unknown",
                 const std::string &md="unknown") :
-            _what("Class=" + cl + 
-                  " Module=" + md + 
-                  " Message:" + message)
-            {}
-  
-        /** Returns the error string. 
-         *  This is the standard diagnostic behavior, since it is 
-         *  virtual it can be overidden 
-         */
-        virtual const char* what() const throw() {
-            return _what.c_str();    
-        }
+          std::runtime_error("")
+              {
+                  std::stringstream ss;
+                  ss << "Class=" << cl
+                     << " Module=" << md
+                     << " Message:" << message;
+                  static_cast<std::runtime_error&>(*this) = std::runtime_error(ss.str());
+              }
 
         virtual ~BaseExc() throw() {}
     };
@@ -67,7 +64,7 @@ namespace MetaSim {
 #define DECL_EXC(EXC, CLASS) \
     class EXC : public BaseExc { public: \
             EXC(const std::string &m) : BaseExc(m, CLASS, __FILE__) {} }
-    
+
 #define THROW_EXC(EXC, MSG) throw EXC(MSG  ":" __LINE__)
 
 } // namespace MetaSim

--- a/src/strtoken.cpp
+++ b/src/strtoken.cpp
@@ -28,7 +28,7 @@ namespace parse_util {
 
                 while (pos != string::npos) {
                         pos = code.find(sep, old_pos);
-                        if (pos != string::npos) { 
+                        if (pos != string::npos) {
                                 temp.push_back(remove_spaces(code.substr(old_pos,pos-old_pos)));
                                 old_pos = pos + sep.size();
                                 count ++;
@@ -50,7 +50,7 @@ namespace parse_util {
 
                 while (pos != string::npos) {
                         pos = code.find(';', old_pos);
-                        if (pos != string::npos) { 
+                        if (pos != string::npos) {
                                 temp.push_back(remove_spaces(code.substr(old_pos,pos-old_pos)));
                                 old_pos = ++pos;
                         }
@@ -81,7 +81,7 @@ namespace parse_util {
                         string::size_type end = instr.find_last_of(close_par);
                         temp = instr.substr(pos+1, end-pos-1);
                 }
-  
+
                 return temp;
         }
 
@@ -103,7 +103,7 @@ namespace parse_util {
                                         if (pos == p.size()) pos = string::npos;
                                         else ++pos;
                                 }
-      
+
                         if (pos != string::npos) {
                                 string t = remove_spaces(p.substr(old_pos, pos - old_pos));
 
@@ -131,20 +131,19 @@ namespace parse_util {
 
                 pos = tmp.find_first_of(symb, pos);
 
-                if (pos != string::npos) 
+                if (pos != string::npos)
                         unit = tmp.substr(pos, tmp.size() - pos);
-                else unit = "";  
-    
+                else unit = "";
+
                 string snum = tmp.substr(0,pos);
                 res = atof(snum.c_str());
         }
-        ParseExc::ParseExc(const string &where, const string &par)
-                : _where(where), _par(par)
-        {
-        }
 
-        string ParseExc::what() 
+        ParseExc::ParseExc(const string &where, const string &par) :
+          std::runtime_error("")
         {
-                return "Parse error: in " + _where + " param(s) " + _par + " is unknown"; 
+              std::stringstream ss;
+              ss << "Parse error: in " << where << " param(s) " << par << " is unknown";
+              static_cast<std::runtime_error&>(*this) = std::runtime_error(ss.str());
         }
 }

--- a/src/strtoken.hpp
+++ b/src/strtoken.hpp
@@ -14,8 +14,9 @@
 #ifndef __STRTOKEN_HPP__
 #define __STRTOKEN_HPP__
 
-#include <exception>
+#include <stdexcept>
 #include <string>
+#include <sstream>
 #include <vector>
 
 #include <baseexc.hpp>
@@ -34,13 +35,13 @@ namespace parse_util {
     /**
        Removes trailing spaces from the beginning and from the end of
        the string \c tk.
-    */ 
+    */
     string remove_spaces(const string &tk);
 
     /**
        Given a string \c code, consisting of many substrings separated
        by the sequence \c sep, returns a vector containing the substrings.
-       For example, given the string "fixed(1);wait(R);" returns the 
+       For example, given the string "fixed(1);wait(R);" returns the
        vector containing strings "fixed(1)" and "wait(R)".
     */
     vector<string> split(const string &code, const string &sep);
@@ -48,8 +49,8 @@ namespace parse_util {
     /**
        Given a sequence of "instructions" spearated by ';', returns a
        vector containing the istructions. Notice that the last
-       instructions must finish with a ';', otherwise it is ignored. 
-     
+       instructions must finish with a ';', otherwise it is ignored.
+
        @todo add sintax error checking!
     */
     vector<string> split_instr(const string &code);
@@ -80,7 +81,7 @@ namespace parse_util {
     */
     vector<string> split_param(const string &p, const string &sep = ",",
                                char open_par = '(', char close_par = ')');
-  
+
     /**
        Given a string of the form "123.75ms" returns the double number
        at the beginning of the string in res and the unit of measure in
@@ -91,13 +92,10 @@ namespace parse_util {
     /**
        Exception raised by the above functions
     */
-    class ParseExc : public exception {
-        string _where;
-        string _par;
+    class ParseExc : public std::runtime_error {
 
     public:
         ParseExc(const string &where, const string &par);
-        string what();
         virtual ~ParseExc() throw () {}
     };
 }


### PR DESCRIPTION
Le eccezioni adesso prendono senza problemi anche dei tipi "std::string" invece del cast automatico a "char *".